### PR TITLE
Show all notes in one note folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ##notes
 |column|data type|    keys   |
 |:----:|:-------:|:---------:|
-|title|string|add_index|
+|title|text|add_index|
 |body|text|add_index|
 |noteFolder_id|integer|foreign_key: true|
 |user_id|integer|foreign_key: true|

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,9 @@
 // note_folders#index
 @import "./note-folder/index";
 
+// note_folders#show
+@import "./note-folder/show";
+
 // sign-up
 @import "./sign-up/base";
 

--- a/app/assets/stylesheets/base/_base.scss
+++ b/app/assets/stylesheets/base/_base.scss
@@ -32,3 +32,14 @@ a{
   height: 0px;
   text-decoration: none;
 }
+a:visited {
+  text-decoration: none;
+  height: 0px;
+  color: #bbbbbb;}
+
+hr{
+  border-top-width: 0px;
+  border-right-width: 1px;
+  border-bottom-width: 1px;
+  border-left-width: 1px;
+}

--- a/app/assets/stylesheets/base/_base.scss
+++ b/app/assets/stylesheets/base/_base.scss
@@ -30,5 +30,5 @@ input{
 
 a{
   height: 0px;
-
+  text-decoration: none;
 }

--- a/app/assets/stylesheets/note-folder/_index.scss
+++ b/app/assets/stylesheets/note-folder/_index.scss
@@ -14,7 +14,7 @@
     .multiple-folders__logo{
       margin-top: 60px;
       margin-bottom: 15px;
-      height: 68px;
+      height: 80px;
       width: auto;
     }
   }

--- a/app/assets/stylesheets/note-folder/_show.scss
+++ b/app/assets/stylesheets/note-folder/_show.scss
@@ -33,12 +33,14 @@
       &__title{
         font-size: 16px;
         font-weight: bold;
+        color: #4a534a;
       }
       &__line{
         margin: 3px 7px;
       }
       &__body{
         font-size: 15px;
+        color: #565c55;
       }
     }
   }

--- a/app/assets/stylesheets/note-folder/_show.scss
+++ b/app/assets/stylesheets/note-folder/_show.scss
@@ -33,7 +33,12 @@
       &__title{
         font-size: 16px;
         font-weight: bold;
-        color: #4a534a;
+        color: #3e3e3e;
+        // 長い文字列を最後・・・にする
+        width: 300px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
       &__line{
         margin: 3px 7px;

--- a/app/assets/stylesheets/note-folder/_show.scss
+++ b/app/assets/stylesheets/note-folder/_show.scss
@@ -23,10 +23,10 @@
     background-color: #F3F3F3;
     overflow-y: scroll;
     &__box{
-      width: 300px;
+      width: 290px;
       height: 100px;
       margin-bottom: 10px;
-      padding: 10px;
+      padding: 15px;
       background-color: #fff;
       border-radius: 7px;
       box-shadow:5px 5px 10px rgba(0, 0, 0, 0.3);
@@ -34,8 +34,9 @@
         font-size: 16px;
         font-weight: bold;
         color: #3e3e3e;
+        padding-left: 10px;
         // 長い文字列を最後・・・にする
-        width: 300px;
+        width: 270px;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -46,6 +47,13 @@
       &__body{
         font-size: 15px;
         color: #565c55;
+        padding: 3px 10px 5px 10px;
+
+        overflow: hidden;
+        word-wrap: break-word;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 3;
       }
     }
   }

--- a/app/assets/stylesheets/note-folder/show.scss
+++ b/app/assets/stylesheets/note-folder/show.scss
@@ -1,0 +1,42 @@
+.top-bar{
+  background-color: #2DBE60;
+  height: 4px;
+  width: 100%;
+}
+.notes{
+  &__header{
+    &__header-back-icon{
+    }
+    &__note-folder-name{
+    }
+    &__new-note-icon{
+    }
+  }
+
+  &__search-bar{
+  }
+
+  &__body{
+    height: calc(100% - 100px - 50px);
+    padding: 20px;
+    background-color: #F3F3F3;
+    overflow: scroll;
+    &__box{
+      width: 270px;
+      height: 230px;
+      padding: 15px;
+      background-color: #fff;
+      border-radius: 7px;
+      box-shadow:5px 5px 10px rgba(0, 0, 0, 0.35);
+      &__title{
+        font-size: 30px;
+        font-weight: bold;
+      }
+      &__line{
+        margin: 5px 10px;
+      }
+      &__body{}
+    }
+  }
+
+}

--- a/app/assets/stylesheets/note-folder/show.scss
+++ b/app/assets/stylesheets/note-folder/show.scss
@@ -17,25 +17,29 @@
   }
 
   &__body{
-    height: calc(100% - 100px - 50px);
-    padding: 20px;
+    height: calc(100% - 4px - 110px - 60px - 20px);
+    padding: 5px;
+    margin-bottom: 0;
     background-color: #F3F3F3;
-    overflow: scroll;
+    overflow-y: scroll;
     &__box{
-      width: 270px;
-      height: 230px;
-      padding: 15px;
+      width: 300px;
+      height: 100px;
+      margin-bottom: 10px;
+      padding: 10px;
       background-color: #fff;
       border-radius: 7px;
-      box-shadow:5px 5px 10px rgba(0, 0, 0, 0.35);
+      box-shadow:5px 5px 10px rgba(0, 0, 0, 0.3);
       &__title{
-        font-size: 30px;
+        font-size: 16px;
         font-weight: bold;
       }
       &__line{
-        margin: 5px 10px;
+        margin: 3px 7px;
       }
-      &__body{}
+      &__body{
+        font-size: 15px;
+      }
     }
   }
 

--- a/app/assets/stylesheets/note/_content.scss
+++ b/app/assets/stylesheets/note/_content.scss
@@ -1,13 +1,13 @@
 .content{
-  width: calc(100% - 300px);
+  width: calc(100% - 350px);
   height: 100%;
   background-color: blue;
   &__header{
-    height: 100px;
+    height: 70px;
     background-color: white;
   }
   &__body{
-    height: calc(100% - 100px);
+    height: calc(100% - 70px);
     background-color: pink;
   }
 }

--- a/app/assets/stylesheets/note/_notes.scss
+++ b/app/assets/stylesheets/note/_notes.scss
@@ -13,7 +13,7 @@
     background-color: #d9ffda;
   }
   &__body{
-    height: calc(100% - 100px - 50px);
+    height: calc(100% - 4px - 110px - 60px - 40px);
     background-color: #F3F3F3;
   }
 }

--- a/app/assets/stylesheets/note/_notes.scss
+++ b/app/assets/stylesheets/note/_notes.scss
@@ -1,18 +1,19 @@
 .notes{
-  width: 300px;
+  width: 350px;
   height: 100%;
-  background-color: red;
+  background-color: #F3F3F3;
   &__header{
     height: 100px;
-    background-color: blue;
+    margin: 5px;
+    background-color: white;
   }
   &__search-bar{
-    height: 53px;
-    background-color: red;
+    height: 50px;
+    margin: 5px;
+    background-color: #d9ffda;
   }
   &__body{
-    height: calc(100% - 100px - 53px);
-    width: 300px;
-    background-color: green;
+    height: calc(100% - 100px - 50px);
+    background-color: #F3F3F3;
   }
 }

--- a/app/controllers/note_folders_controller.rb
+++ b/app/controllers/note_folders_controller.rb
@@ -19,7 +19,7 @@ class NoteFoldersController < ApplicationController
 
   def show
     @note_folder = NoteFolder.find(params[:id])
-    @notes = @note_folder.notes
+    @notes = @note_folder.notes.order("updated_at DESC")
   end
 
   private

--- a/app/controllers/note_folders_controller.rb
+++ b/app/controllers/note_folders_controller.rb
@@ -19,6 +19,7 @@ class NoteFoldersController < ApplicationController
 
   def show
     @note_folder = NoteFolder.find(params[:id])
+    @notes = @note_folder.notes
   end
 
   private

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,4 +1,9 @@
 class NotesController < ApplicationController
   def index
   end
+
+  def show
+    @note = Note.find(params[:id])
+    @notes = Note.where(note_folder_id: @note.note_folder_id)
+  end
 end

--- a/app/views/note_folders/_note_folder.html.haml
+++ b/app/views/note_folders/_note_folder.html.haml
@@ -1,5 +1,5 @@
 = link_to note_folder_path(note_folder) do
   .note-folder-index__body__content
-    %img{class: "evernote-lite__logo", :alt => "evernote-lite", :border => "0", :height => "68", :width => "68", :src => "https://chat-space-demo.herokuapp.com/uploads/message/image/22622/217861.png"}/
+    %img{class: "evernote-lite__logo", :alt => "evernote-lite", :border => "0", :height => "68", :width => "68", :src => "https://s3-ap-northeast-1.amazonaws.com/chatspace-development/uploads/message/image/576/179475.png"}/
     %p.group_name_small
       = note_folder.name

--- a/app/views/note_folders/index.html.haml
+++ b/app/views/note_folders/index.html.haml
@@ -1,10 +1,10 @@
 .note-folder-index
   .top-bar
   .note-folder-index__top
-    %img{class: "multiple-folders__logo", :alt => "evernote-lite", :border => "0", :src => "https://chat-space-demo.herokuapp.com/uploads/message/image/22612/folders1.png"}/
+    %img{class: "multiple-folders__logo", :alt => "evernote-lite", :border => "0", :src => "https://s3-ap-northeast-1.amazonaws.com/chatspace-development/uploads/message/image/572/folders1.png"}/
   %h1 【 #{current_user.name}さん 】 のフォルダ
   .note-folder-index__body
     = render @note_folders
     .note-folder-index__body__last-content
-      %img{class: "last-content__logo", :alt => "evernote-lite", :border => "0", :height => "68", :width => "68", :src => "https://chat-space-demo.herokuapp.com/uploads/message/image/22732/179474.png"}/
+      %img{class: "last-content__logo", :alt => "evernote-lite", :border => "0", :height => "68", :width => "68", :src => "https://s3-ap-northeast-1.amazonaws.com/chatspace-development/uploads/message/image/574/179474.png"}/
       %p 新規フォルダの作成

--- a/app/views/note_folders/show.html.haml
+++ b/app/views/note_folders/show.html.haml
@@ -6,9 +6,4 @@
     .notes__header__new-note-icon
   .notes__search-bar
   .notes__body
-    .notes__body__box
-      .notes__body__box__title
-        = @note.title
-      %hr.notes__body__box__line/
-      .notes__body__box__body
-        = @note.body
+    = render @notes

--- a/app/views/note_folders/show.html.haml
+++ b/app/views/note_folders/show.html.haml
@@ -1,1 +1,14 @@
-yahho--------
+.top-bar
+.notes
+  .notes__header
+    %img{class: "note__header__back-icon", :alt => "evernote-lite", :border => "0", :src => "https://s3-ap-northeast-1.amazonaws.com/chatspace-development/uploads/message/image/582/187704.png", :width => "68"}/
+    .notes__header__note-folder-name
+    .notes__header__new-note-icon
+  .notes__search-bar
+  .notes__body
+    .notes__body__box
+      .notes__body__box__title
+        = @note.title
+      %hr.notes__body__box__line/
+      .notes__body__box__body
+        = @note.body

--- a/app/views/notes/_note.html.haml
+++ b/app/views/notes/_note.html.haml
@@ -1,6 +1,5 @@
 = link_to note_path(note) do
   .notes__body__box
-    // titleは32文字まで表示。
     .notes__body__box__title
       = note.title
     %hr.notes__body__box__line/

--- a/app/views/notes/_note.html.haml
+++ b/app/views/notes/_note.html.haml
@@ -1,0 +1,8 @@
+= link_to note_path(note) do
+  .notes__body__box
+    // titleは32文字まで表示。
+    .notes__body__box__title
+      = note.title
+    %hr.notes__body__box__line/
+    .notes__body__box__body
+      = note.body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root 'notes#index'
   resources :note_folders
+  resources :notes
 end


### PR DESCRIPTION
# WHAT
ノートフォルダのノートをpartialを用いてサイドバーに降順で表示。
notes#showへlink_toで繋いだ。

それに伴い、文字数の多いtitleやbodyについては文字を切り取り・・・をつけることで対応。

# WHY
フォルダ分けをした利便性を出すために
フォルダ毎のノートの表示機能が必要だから。