### PR TITLE
Move new note icon from notes header to content header

### DIFF
--- a/app/assets/stylesheets/note-folder/_show-header.scss
+++ b/app/assets/stylesheets/note-folder/_show-header.scss
@@ -6,13 +6,12 @@
     height: 45px;
   }
   &__note-folder-name{
+    width: 240px;
     font-size: 25px;
     font-weight: bold;
     color: #3BC26B;
-    text-align: center;
     text-decoration: underline;
 
-    width: 150px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/app/assets/stylesheets/note/_index.scss
+++ b/app/assets/stylesheets/note/_index.scss
@@ -5,7 +5,6 @@
       font-size: 25px;
       font-weight: bold;
       color: #3BC26B;
-      text-align: center;
       text-decoration: underline;
 
       // 長いタイトルを・・・にする

--- a/app/assets/stylesheets/note/_index.scss
+++ b/app/assets/stylesheets/note/_index.scss
@@ -1,7 +1,7 @@
 .notes{
   &__header{
     &__name{
-      width: 150px;
+      width: 240px;
       font-size: 25px;
       font-weight: bold;
       color: #3BC26B;

--- a/app/assets/stylesheets/shared/_content__header.scss
+++ b/app/assets/stylesheets/shared/_content__header.scss
@@ -1,8 +1,11 @@
 .content__header{
   @include flex-row-wrap-space-around;
   align-items: center;
+  &__new-note-icon{
+    margin-left: 12px;
+  }
   &__functions{
-    width: 230px;
+    width: 150px;
     height: 100%;
   }
   &__note-title{

--- a/app/controllers/note_folders_controller.rb
+++ b/app/controllers/note_folders_controller.rb
@@ -24,7 +24,9 @@ class NoteFoldersController < ApplicationController
   end
 
   def edit
-    @note_folder = NoteFolder.find(params[:id])
+    @note = Note.find(params[:id])
+    id = @note.note_folder_id
+    @note_folder = NoteFolder.find(id)
   end
 
   def update

--- a/app/views/notes/index.html.haml
+++ b/app/views/notes/index.html.haml
@@ -9,8 +9,6 @@
             %img{class: "notes__header__go-folders-icon", :alt => "evernote-lite", :border => "0", :src => "https://cdn-ak.f.st-hatena.com/images/fotolife/k/kochan214/20170215/20170215161054.png"}/
           = link_to edit_user_registration_path do
             .notes__header__name #{current_user.name}
-          = link_to new_note_path do
-            %img{class: "notes__header__new-note-icon", :alt => "evernote-lite", :border => "0", :src => "https://cdn-ak.f.st-hatena.com/images/fotolife/k/kochan214/20170215/20170215160111.png"}/
         .notes__search-bar
         .notes__body
           = render @notes

--- a/app/views/shared/_content.html.haml
+++ b/app/views/shared/_content.html.haml
@@ -4,6 +4,9 @@
 -else
   .content
     .content__header
+      .content__header__new-note-icon
+        = link_to new_note_path do
+          %img{class: "notes__header__new-note-icon", :alt => "evernote-lite", :border => "0", :src => "https://cdn-ak.f.st-hatena.com/images/fotolife/k/kochan214/20170215/20170215160111.png"}/
       .content__header__functions
         B U A a A
       .content__header__note-title

--- a/app/views/shared/_not-all-note-header.html.haml
+++ b/app/views/shared/_not-all-note-header.html.haml
@@ -5,6 +5,3 @@
   = link_to edit_note_folder_path do
     .notes__header__note-folder-name
       = @note_folder.name
-  = link_to new_note_path do
-    .notes__header__new-note-icon
-      %img{class: "notes__header__new-note-icon", :alt => "evernote-lite", :border => "0", :src => "https://cdn-ak.f.st-hatena.com/images/fotolife/k/kochan214/20170215/20170215160111.png"}/


### PR DESCRIPTION
# WHAT
- Move new note icon from notes header to content header

- fix note_folders#edit (path)

# WHY
UIを良くするため
（左のヘッダー部分に大きく名前を表示する）