### PR TITLE
Make edit view as a main view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,10 @@
 @import "./shared/content__header";
 @import "./shared/content__body";
 
+@import "./shared/form-content";
+@import "./shared/form-content__header";
+@import "./shared/form-content__body";
+
 // notes#index
 @import "./note/notes";
 @import "./note/index";

--- a/app/assets/stylesheets/misc/_functions.scss
+++ b/app/assets/stylesheets/misc/_functions.scss
@@ -17,3 +17,23 @@
   flex-flow: row wrap;
   justify-content: space-around;
 }
+
+@mixin placeholderColor($color) {
+    &:placeholder-shown {
+        color: $color;
+    }
+    &::-webkit-input-placeholder {
+        color:$color;
+    }
+    &:-moz-placeholder {
+        color:$color;
+        opacity: 1;
+    }
+    &::-moz-placeholder {
+        color:$color;
+        opacity: 1;
+    }
+    &:-ms-input-placeholder {
+        color:$color;
+    }
+}

--- a/app/assets/stylesheets/misc/_functions.scss
+++ b/app/assets/stylesheets/misc/_functions.scss
@@ -21,19 +21,24 @@
 @mixin placeholderColor($color) {
     &:placeholder-shown {
         color: $color;
+        font-weight: lighter;
     }
     &::-webkit-input-placeholder {
         color:$color;
+        font-weight: lighter;
     }
     &:-moz-placeholder {
         color:$color;
         opacity: 1;
+        font-weight: lighter;
     }
     &::-moz-placeholder {
         color:$color;
         opacity: 1;
+        font-weight: lighter;
     }
     &:-ms-input-placeholder {
         color:$color;
+        font-weight: lighter; 
     }
 }

--- a/app/assets/stylesheets/note-folder/_show-header.scss
+++ b/app/assets/stylesheets/note-folder/_show-header.scss
@@ -1,11 +1,11 @@
 .notes__header{
   &__back-icon{
-    position: absolute; top: 12px; left: 5px;
+    position: absolute; top: 8px; left: 7px;
     width: 45px;
     height: 45px;
   }
   &__note-folder-name{
-    position: absolute; top: 27px; left: 70px;
+    position: absolute; top: 20px; left: 72px;
     max-width: 240px;
     font-size: 25px;
     font-weight: bold;

--- a/app/assets/stylesheets/note-folder/_show-header.scss
+++ b/app/assets/stylesheets/note-folder/_show-header.scss
@@ -1,12 +1,12 @@
 .notes__header{
-  @include flex-row-wrap-space-around;
-  align-items: center;
   &__back-icon{
+    position: absolute; top: 12px; left: 5px;
     width: 45px;
     height: 45px;
   }
   &__note-folder-name{
-    width: 240px;
+    position: absolute; top: 27px; left: 70px;
+    max-width: 240px;
     font-size: 25px;
     font-weight: bold;
     color: #3BC26B;

--- a/app/assets/stylesheets/note/_notes.scss
+++ b/app/assets/stylesheets/note/_notes.scss
@@ -3,8 +3,9 @@
   height: 100%;
   background-color: #F3F3F3;
   &__header{
-    height: 80px;
-    margin: 0 5px 5px 5px;
-    background-color: #ecffe0;
+    height: 60px;
+    margin: 5px;
+    background-color: #d8f4c6;
+    border-radius: 20px;
   }
 }

--- a/app/assets/stylesheets/shared/_form-content.scss
+++ b/app/assets/stylesheets/shared/_form-content.scss
@@ -1,0 +1,9 @@
+.edit_note{
+  width: 100%;
+  height: 100%;
+}
+.form-content{
+  width: 100%;
+  height: 100%;
+  background-color: #F3F3F3;
+}

--- a/app/assets/stylesheets/shared/_form-content__body.scss
+++ b/app/assets/stylesheets/shared/_form-content__body.scss
@@ -1,0 +1,19 @@
+.form-content__body{
+  height: calc(100% - 85px);
+  width: 100%;
+  &__text{
+    height: calc(100% - 28px);
+    width: calc(100% - 52px);
+    margin: 0 5px;
+    padding: 20px;
+    border-radius: 8px;
+    border-color: white;
+
+    // 本文に対するCSS
+    font-size: 18px;
+  }
+  &__text:focus{
+    outline: 0px;
+    box-shadow: 0 0 0 4px rgba(138, 242, 74, 0.4);
+  }
+}

--- a/app/assets/stylesheets/shared/_form-content__body.scss
+++ b/app/assets/stylesheets/shared/_form-content__body.scss
@@ -11,6 +11,9 @@
 
     // 本文に対するCSS
     font-size: 18px;
+    color: #3e3e3e;
+
+    @include placeholderColor(#C6C6C6);
   }
   &__text:focus{
     outline: 0px;

--- a/app/assets/stylesheets/shared/_form-content__header.scss
+++ b/app/assets/stylesheets/shared/_form-content__header.scss
@@ -1,0 +1,35 @@
+.form-content__header{
+  height: 80px;
+  margin: 0 5px 5px;
+  @include flexInitialize;
+  align-items: center;
+  .form-content__header__icon{
+    width: 75px;
+    height: auto;
+    margin: 10px 15px 0;
+  }
+  &__note-title{
+    width: calc(100% - 200px);
+    font-size: 35px;
+    font-weight: bold;
+    color: #3BC26B;
+    text-align: center;
+    @include placeholderColor(#c6c6c6);
+
+    // 長いタイトルを・・・にする
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    background-color: #F3F3F3;
+    border-color: #F3F3F3;
+  }
+  &__note-title:focus{
+    background-color: white;
+    outline: 0px;
+    box-shadow: 0 0 0 4px rgba(138, 242, 74, 0.4);
+  }
+  .delete-note-icon{
+    margin-right: 20px;
+  }
+}

--- a/app/assets/stylesheets/shared/_notes__body.scss
+++ b/app/assets/stylesheets/shared/_notes__body.scss
@@ -5,7 +5,7 @@
 }
 .notes{
   &__body{
-    height: calc(100% - 124px);
+    height: calc(100% - 105px);
     padding: 5px;
     margin-bottom: 0;
     background-color: #F3F3F3;

--- a/app/assets/stylesheets/shared/_notes__body.scss
+++ b/app/assets/stylesheets/shared/_notes__body.scss
@@ -34,6 +34,7 @@
         font-weight: bold;
         color: #bce4ca;
         padding-left: 10px;
+        font-weight: lighter;
       }
       &__line{
         margin: 3px 7px;
@@ -53,6 +54,7 @@
         font-size: 15px;
         color: #c7c9c5;
         padding: 3px 10px 5px 10px;
+        font-weight: lighter; 
       }
     }
   }

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -35,7 +35,8 @@ class NotesController < ApplicationController
   end
 
   def update
-    if @note = Note.update(set_params)
+    @note = Note.find(params[:id])
+    if @note.update(set_params)
       redirect_to note_folder_path(@note_folder)
     else
       redirect_to new_note_path, alert: 'ノートの作成に失敗しました'

--- a/app/views/notes/show.html.haml
+++ b/app/views/notes/show.html.haml
@@ -5,4 +5,4 @@
     .notes__search-bar
     .notes__body
       = render partial: "shared/notes__body", locals: {note_folder: @note_folder, notes: @notes}
-  = render partial: "shared/content"
+  = render partial: "shared/form-content"

--- a/app/views/shared/_form-content.html.haml
+++ b/app/views/shared/_form-content.html.haml
@@ -1,0 +1,13 @@
+= form_for [@note_folder, @note] do |f|
+  .form-content
+    .form-content__header
+      = link_to new_note_folder_note_path(@note_folder) do
+        %img{class: "form-content__header__icon", :alt => "evernote-lite", :border => "0", :src => "https://cdn-ak.f.st-hatena.com/images/fotolife/k/kochan214/20170215/20170215160111.png"}/
+
+      = f.text_field :title, placeholder: 'タイトルがありません', class: 'form-content__header__note-title'
+
+      = link_to note_folder_note_path(@note_folder, @note), method: :delete do
+        %img{class: "form-content__header__icon delete-note-icon", :alt => "evernote-lite", :border => "0", :src => "https://cdn-ak.f.st-hatena.com/images/fotolife/k/kochan214/20170215/20170215160512.png"}/
+
+    .form-content__body
+      = f.text_area :body, placeholder: '本文がありません', class: 'form-content__body__text'


### PR DESCRIPTION
# WHAT
フォームをノートのメインビューに表示し、その他微調整を加えた。

- create form-content.html.haml
- create 3 scss for form-content, header, body
- tune up form scss
- remove no need icons from form-header 
- fine tune notes header

# WHY
ノートのメイン画面から入力できるようにするため。