### PR TITLE
Change path to notes#show

### DIFF
--- a/app/assets/stylesheets/shared/_form-content__header.scss
+++ b/app/assets/stylesheets/shared/_form-content__header.scss
@@ -14,6 +14,7 @@
     font-weight: bold;
     color: #3BC26B;
     text-align: center;
+    font-weight: lighter;
     @include placeholderColor(#c6c6c6);
 
     // 長いタイトルを・・・にする

--- a/app/assets/stylesheets/sign-up/_base.scss
+++ b/app/assets/stylesheets/sign-up/_base.scss
@@ -20,6 +20,8 @@
     width: 380px;
     padding: 10px 0 20px 0;
     background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 0 0 2.5px rgba(138, 242, 74, 0.4);
     @include flex-column-center;
     &__confirmation-sentence{
       margin: 10px 30px;
@@ -30,6 +32,7 @@
       background-color: #2DBE60;
       border-style: none;
       margin-top: 30px;
+      font-size: 18px;
     }
   }
   .registration__bottom{

--- a/app/controllers/note_folders_controller.rb
+++ b/app/controllers/note_folders_controller.rb
@@ -19,8 +19,8 @@ class NoteFoldersController < ApplicationController
   end
 
   def show
-    @notes = @note_folder.notes.order("updated_at DESC")
     @note = @note_folder.notes.last
+    redirect_to note_folder_note_path(@note_folder, @note)
   end
 
   def edit

--- a/app/controllers/note_folders_controller.rb
+++ b/app/controllers/note_folders_controller.rb
@@ -20,7 +20,12 @@ class NoteFoldersController < ApplicationController
 
   def show
     @note = @note_folder.notes.last
-    redirect_to note_folder_note_path(@note_folder, @note)
+    unless @note.nil?
+      # 最新のノートのshowに飛ばす
+      redirect_to note_folder_note_path(@note_folder, @note)
+    else
+      @notes = @note_folder.notes
+    end
   end
 
   def edit

--- a/app/views/note_folders/show.html.haml
+++ b/app/views/note_folders/show.html.haml
@@ -5,4 +5,4 @@
     .notes__search-bar
     .notes__body
       = render partial: "shared/notes__body", locals: {note_folder: @note_folder, notes: @notes}
-  = render partial: "shared/content"
+  = render partial: "shared/form-content"

--- a/app/views/shared/_form-content.html.haml
+++ b/app/views/shared/_form-content.html.haml
@@ -1,13 +1,23 @@
-= form_for [@note_folder, @note] do |f|
-  .form-content
-    .form-content__header
-      = link_to new_note_folder_note_path(@note_folder) do
-        %img{class: "form-content__header__icon", :alt => "evernote-lite", :border => "0", :src => "https://cdn-ak.f.st-hatena.com/images/fotolife/k/kochan214/20170215/20170215160111.png"}/
+-if @note.nil?
+  .content
+    .content__header
+      .content__header__new-note-icon
+        = link_to new_note_folder_note_path(@note_folder) do
+          %img{class: "notes__header__new-note-icon", :alt => "evernote-lite", :border => "0", :src => "https://cdn-ak.f.st-hatena.com/images/fotolife/k/kochan214/20170215/20170215160111.png"}/
+          新規ノートを作成してください！
+-else
+  = form_for [@note_folder, @note] do |f|
+    .form-content
+      .form-content__header
+        = link_to new_note_folder_note_path(@note_folder) do
+          %img{class: "form-content__header__icon", :alt => "evernote-lite", :border => "0", :src => "https://cdn-ak.f.st-hatena.com/images/fotolife/k/kochan214/20170215/20170215160111.png"}/
 
-      = f.text_field :title, placeholder: 'タイトルがありません', class: 'form-content__header__note-title'
+        = f.text_field :title, placeholder: 'タイトルがありません', class: 'form-content__header__note-title'
 
-      = link_to note_folder_note_path(@note_folder, @note), method: :delete do
-        %img{class: "form-content__header__icon delete-note-icon", :alt => "evernote-lite", :border => "0", :src => "https://cdn-ak.f.st-hatena.com/images/fotolife/k/kochan214/20170215/20170215160512.png"}/
+        = link_to note_folder_note_path(@note_folder, @note), method: :delete do
+          %img{class: "form-content__header__icon delete-note-icon", :alt => "evernote-lite", :border => "0", :src => "https://cdn-ak.f.st-hatena.com/images/fotolife/k/kochan214/20170215/20170215160512.png"}/
 
-    .form-content__body
-      = f.text_area :body, placeholder: '本文がありません', class: 'form-content__body__text'
+      .form-content__body
+        = f.text_area :body, placeholder: '本文がありません', class: 'form-content__body__text'
+      .button
+        = f.submit "ノートの変更を保存", class: 'registration__form__button'


### PR DESCRIPTION
# WHAT
フォルダ一覧から選んだ時に、最新のnoteのshowに飛ぶように設定。

noteがないときの例外も設定。

# WHY
フォルダに入った時に、すぐにそのノートを編集したいが、
note_folder#showのアクションだとnoteのidが入らなく、エラーが出るから。